### PR TITLE
feat: add the engine gsheets data to notion database

### DIFF
--- a/Notion/Notion_Push_data_from_Gsheets.ipynb
+++ b/Notion/Notion_Push_data_from_Gsheets.ipynb
@@ -1,0 +1,344 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "376b5196-ad01-4faa-bd8f-2e86d5030563",
+   "metadata": {},
+   "source": [
+    "<img width=\"10%\" alt=\"Naas\" src=\"https://landen.imgix.net/jtci2pxwjczr/assets/5ice39g4.png?w=160\"/>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0d0f565d-2dbb-4d15-bfe5-99cc37411338",
+   "metadata": {},
+   "source": [
+    "# Notion - Push data from Gsheets"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d8ecd989-e9a2-4063-a215-47bdab8511d2",
+   "metadata": {},
+   "source": [
+    "## Input"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "82b0066b-5a31-45de-b63c-1fa8fe9b3195",
+   "metadata": {},
+   "source": [
+    "### Import librairies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28273fb8-3469-42a9-8c02-6690cb257476",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from naas_drivers import notion, gsheet\n",
+    "import pandas as pd\n",
+    "try:\n",
+    "    import pydash\n",
+    "except:\n",
+    "    !pip install pydash\n",
+    "    import pydash"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3841af2c-a6a0-4193-abf4-a769d8ebd0b5",
+   "metadata": {},
+   "source": [
+    "### Variables"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2921092d-432a-4010-9154-cc3177974220",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Notion\n",
+    "token = \"\"\n",
+    "database_id = \"\"\n",
+    "\n",
+    "# Gsheet\n",
+    "spreadsheet_id = \"SPREADSHEET_ID\"\n",
+    "sheet_name = 'NAME_OF_THE_SHEET'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fd76e948-04a2-4bc1-90a7-8140edccf738",
+   "metadata": {},
+   "source": [
+    "### Mapping the columns name"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ce0f7749-b135-4769-b046-c08c6df946ab",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "mapping = {\n",
+    "    \"NAME_OF_THE_COLUMN_IN_THE_SHEET\": 'NAME_OF_THE_COLUMN_IN_NOTION'\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "07586b13-6d49-4509-81ba-a4522c38acc9",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Get database from notion"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "afbeb540-10a2-45b2-86c9-94cbdccfa9e3",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "database = notion.connect(token).database.get(database_id)\n",
+    "df_db = database.df()\n",
+    "df_db"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "780dbf10-44b8-4ee8-8675-4380c1cba0b7",
+   "metadata": {},
+   "source": [
+    "### Get unique Token from notion database"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "37eac390-be7b-4f21-987e-a91581ad778d",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# The unique Token is a variable that serve to compare the two set of data\n",
+    "try:\n",
+    "    tokens = df_db.Token.unique()\n",
+    "    tokens\n",
+    "except:\n",
+    "    tokens = []"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c17c363b-bedb-424d-b925-b313cb16dcd0",
+   "metadata": {},
+   "source": [
+    "### Get data from gsheet"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "abc50da4-fd26-4eed-b5dd-085a5be82021",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "df_gsheets = gsheet.connect(spreadsheet_id).get(sheet_name)\n",
+    "df_gsheets"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "76fc03c8-af53-459e-b958-49c66d619608",
+   "metadata": {},
+   "source": [
+    "## Model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6bf9c859-d7e9-4c1e-a3a1-914a0b50202a",
+   "metadata": {},
+   "source": [
+    "### Cleaning gsheet"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2e99d57b-8f3c-49d8-8e62-9827cd61d86f",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "gs_clean = df_gsheets.copy()\n",
+    "\n",
+    "# Change columns name to match with notion database\n",
+    "gs_clean = gs_clean.rename(columns=mapping)\n",
+    "\n",
+    "gs_clean"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f39ba83c-a84f-4759-824f-a4571a6b7fa9",
+   "metadata": {},
+   "source": [
+    "### Concat dataframe and rows to update"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eea992f9-ba66-4276-8042-74762733d2b2",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "df_concat = pd.concat([gs_clean, df_db]).drop_duplicates(keep=False).drop_duplicates(\"Token\", keep='first').reset_index(drop=True)\n",
+    "df_concat"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4f05f9f5-6cb6-4fe4-818c-e6b5f7d0be14",
+   "metadata": {},
+   "source": [
+    "## Output"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1597a8b1-5681-465a-b024-3f9abab80923",
+   "metadata": {},
+   "source": [
+    "### Update page in notion"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0d3bcfa5-d190-4293-8cd0-52c3ac6c49f3",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def update_page_in_notion(page, df_gsheets):\n",
+    "    responses = df_gsheets.values\n",
+    "    for response in responses:\n",
+    "        # response[14] is the token receive from the sheets data\n",
+    "        if response[14] == token:\n",
+    "            # Here you can map the page of the DB with your data from the sheet\n",
+    "            page.title(\"Token\", response[14])\n",
+    "    page.update()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "95ec305c-559f-4240-8f78-751f3aff75a2",
+   "metadata": {},
+   "source": [
+    "### Write page in notion"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "79253981-0990-4f21-8a26-cb802f71e765",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def write_in_notion(df_gsheets, database, token):\n",
+    "    responses = df_gsheets.values\n",
+    "    page = notion.Page.new(database_id=database_id).create()\n",
+    "    for response in responses:\n",
+    "        # response[14] is the token receive from the sheets data\n",
+    "        if response[14] == token:\n",
+    "            # Here you can map the page of the DB with your data from the sheet\n",
+    "            page.title(\"Token\", response[14])\n",
+    "    page.update()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "09c529b3-c927-4f57-98e8-6200d75e97f1",
+   "metadata": {},
+   "source": [
+    "### Sync Gsheet with Notion database"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d7df5f95-4b0d-4990-9dce-010d13eebec2",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "for _, row in df_concat.iterrows():\n",
+    "    print(_)\n",
+    "    token = row.Token\n",
+    "    if token in tokens:\n",
+    "        # Update dabase in notion\n",
+    "        print(\"Update database :\", token)\n",
+    "        for page in database.query():\n",
+    "            page_temp = page.df()\n",
+    "            if token == page_temp.values[9][2]:\n",
+    "                print(\"Updating..\")\n",
+    "                update_page_in_notion(page, df_concat, token)\n",
+    "    else:\n",
+    "        # Create page in notion database\n",
+    "        print(\"New page created in Notion :\")\n",
+    "        write_in_notion(df_concat, database, token)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Hi !

I add the engine gsheets data to notion database,
In the notebook, you have to put your gsheet spreadsheet_id, the name of the sheet, your notion token and the database ID.

After that, you have to put your unique variable to compare the two set of data.

And for the finish, you have to fill the two functions `write_in_notion` and `update_page_in_notion`

**Exemple,** `response[1]` is the date, you ahve to write in the two function `page.date("Date", response[1])`

I stay available for all questions for the use of the notebook, thank you in advance for your feedback!
