### PR TITLE
feat: Notion - Automate transcript generation from recording link in page property

### DIFF
--- a/Notion/Notion_Automate_transcript_generation_from_recording_link_in_page_property.ipynb
+++ b/Notion/Notion_Automate_transcript_generation_from_recording_link_in_page_property.ipynb
@@ -1,0 +1,753 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "753afbf7-26a1-4297-b98d-bbf43f50a8d6",
+   "metadata": {},
+   "source": [
+    "<img width=\"10%\" alt=\"Naas\" src=\"https://landen.imgix.net/jtci2pxwjczr/assets/5ice39g4.png?w=160\"/>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "de19af8d-2ab8-4282-b4e3-66d94141d153",
+   "metadata": {},
+   "source": [
+    "# Notion - Automate transcript generation from recording link in page property\n",
+    "<a href=\"https://app.naas.ai/user-redirect/naas/downloader?url=https://raw.githubusercontent.com/jupyter-naas/awesome-notebooks/master/Notion/Notion_Create_page.ipynb\" target=\"_parent\"><img src=\"https://naasai-public.s3.eu-west-3.amazonaws.com/open_in_naas.svg\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e40736cb-fc58-4329-9c93-f08f0b4b45e2",
+   "metadata": {},
+   "source": [
+    "**Tags:** #notion #aws #transcribe #S3 #automation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b9463497-8521-4aaa-8138-7e52c47a6f72",
+   "metadata": {},
+   "source": [
+    "**Author:** [Maxime Jublou](https://www.linkedin.com/in/maximejublou)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "72e1a719-c669-4682-bce9-c79792cbb6a2",
+   "metadata": {},
+   "source": [
+    "This notebook is used to automatically add to a notion page, the transcript of a recording that would be found in the `Recording` property of that same page.\n",
+    "\n",
+    "Recordings can be in any language compatible with AWS transcribe ([Here is the list](https://docs.aws.amazon.com/transcribe/latest/dg/supported-languages.html))\n",
+    "\n",
+    "As of today, you also need to upload the recordings on Google Drive. (Feel free to open an issue [here](https://github.com/jupyter-naas/awesome-notebooks/issues/new?assignees=&labels=&template=template-request.md&title=Notion%20-%20Automatic%20transcribe%20recording%20-%20Add%20Zoom%20recording%20sources) if you want more recording sources like Zoom, etc to be developed.)\n",
+    "\n",
+    "To setup this Notebook you need to have:\n",
+    "\n",
+    "1. An AWS Account + an IAM user having the following permissions:\n",
+    "```json\n",
+    "{\n",
+    "    \"Version\": \"2012-10-17\",\n",
+    "    \"Statement\": [\n",
+    "        {\n",
+    "            \"Effect\": \"Allow\",\n",
+    "            \"Action\": [\n",
+    "                \"s3:*\",\n",
+    "                \"s3-object-lambda:*\"\n",
+    "            ],\n",
+    "            \"Resource\": \"*\"\n",
+    "        }\n",
+    "    ]\n",
+    "}\n",
+    "```\n",
+    "_⚠️ This IAM permission is too broad, you should limit it to a single S3 bucket._\n",
+    "\n",
+    "and\n",
+    "\n",
+    "```json\n",
+    "{\n",
+    "    \"Version\": \"2012-10-17\",\n",
+    "    \"Statement\": [\n",
+    "        {\n",
+    "            \"Effect\": \"Allow\",\n",
+    "            \"Action\": [\n",
+    "                \"transcribe:*\"\n",
+    "            ],\n",
+    "            \"Resource\": \"*\"\n",
+    "        },\n",
+    "        {\n",
+    "            \"Effect\": \"Allow\",\n",
+    "            \"Action\": [\n",
+    "                \"s3:GetObject\"\n",
+    "            ],\n",
+    "            \"Resource\": [\n",
+    "                \"arn:aws:s3:::*transcribe*\"\n",
+    "            ]\n",
+    "        }\n",
+    "    ]\n",
+    "}\n",
+    "```\n",
+    "2. An AWS S3 bucket where we will be able to push video files and get JSON transcripts.\n",
+    "3. A Notion integration that will have read/write access to your Notion database.\n",
+    "    1. [Get your Notion integration token](https://docs.naas.ai/drivers/notion)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8afbed83-450e-4a43-b19e-0edca9fd5409",
+   "metadata": {},
+   "source": [
+    "## Input"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9058cbb9-c248-4f29-b1d7-617b990fa5ff",
+   "metadata": {},
+   "source": [
+    "### Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8953f7b6-bc16-4c5f-82ca-d50bf171e20c",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Used to access nested properties in dictionnaries.\n",
+    "import pydash as _\n",
+    "\n",
+    "# Used to run multiple jobs at once.\n",
+    "import threading, queue\n",
+    "import uuid\n",
+    "\n",
+    "# Used for nicer cell outputs.\n",
+    "try:\n",
+    "    from rich import print\n",
+    "except:\n",
+    "    ! pip install --user rich\n",
+    "    from rich import print\n",
+    "\n",
+    "# Used for transcript generation.\n",
+    "import sys\n",
+    "import json\n",
+    "import datetime\n",
+    "import codecs\n",
+    "import time\n",
+    "import os\n",
+    "\n",
+    "# Used for email rendering.\n",
+    "import markdown\n",
+    "\n",
+    "# Used to download files from google drive.\n",
+    "try:\n",
+    "    import gdown\n",
+    "except:\n",
+    "    !pip install gdown\n",
+    "    import gdown\n",
+    "\n",
+    "# Used to interact with AWS, here S3 and Transcribe.\n",
+    "try:\n",
+    "    import boto3\n",
+    "except:\n",
+    "    ! pip install --user boto3\n",
+    "    \n",
+    "# Used to interact with Notion.\n",
+    "from naas_drivers import notion\n",
+    "from naas_drivers.tools.notion import BlockTypeFactory\n",
+    "\n",
+    "# Used to schedule, send notification, get/store secrets.\n",
+    "import naas"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5d590508-2590-47f4-89d3-f14946f8471c",
+   "metadata": {},
+   "source": [
+    "### Input parameters\n",
+    "\n",
+    "- [Get your Notion integration token](https://docs.naas.ai/drivers/notion) (Once you have it you also need to share your database with this integration.)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e86782d4-21c4-4680-ae36-caf323140eeb",
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# Notion secret\n",
+    "NOTION_TOKEN = naas.secret.get('tf_notion_token')\n",
+    "NOTION_DATABASE_ID = \"your notion database id\"\n",
+    "\n",
+    "# AWS Secret.\n",
+    "# IAM permissions to S3 and Transcribe are needed to have this template working.\n",
+    "AWS_ACCESS_KEY_ID = naas.secret.get('aws_transcribe_s3_key')\n",
+    "AWS_SECRET_ACCESS_KEY = naas.secret.get('aws_transcribe_s3_secret')\n",
+    "AWS_REGION = 'eu-west-3'\n",
+    "\n",
+    "# AWS S3 Bucket name that will be used to send recording and fetch transcripts.\n",
+    "BUCKET_NAME = \"your-existing-s3-bucket\"\n",
+    "\n",
+    "# To whom we need to send notification errors.\n",
+    "EMAIL_ERROR_TO = \"maxime@naas.ai\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a9c8f4da-a21e-4910-9b60-8ff6d9240e06",
+   "metadata": {},
+   "source": [
+    "### Setup Notion"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3a3b461b-32e5-4894-b4fa-737b94867491",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "notion.connect(NOTION_TOKEN)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "709e4ed4-4303-41ca-8666-9c3df4040df9",
+   "metadata": {},
+   "source": [
+    "## Model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "df8a0e6b-f635-4227-a927-0f62df7110be",
+   "metadata": {},
+   "source": [
+    "### Load database"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "06dbc190-3064-4675-b1fb-e27389489673",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "database = notion.connect(NOTION_TOKEN).databases.get(NOTION_DATABASE_ID)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "395a22b1-f9ba-4ae6-8bc9-e72bd5a7601d",
+   "metadata": {},
+   "source": [
+    "### Error notifier"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ea56125c-cf04-4fea-8259-48d1ae45463e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def send_error_notification(notion_page, error):\n",
+    "    email_to = EMAIL_ERROR_TO\n",
+    "    subject = \"🛎️ Transcript error 🚨\"\n",
+    "    content = markdown.markdown(\n",
+    "f'''\n",
+    "# 🚨 An error occured while generating transcript.\n",
+    "\n",
+    "Notion page: {notion_page}\n",
+    "\n",
+    "## Error:\n",
+    "\n",
+    "> {error}\n",
+    "\n",
+    "''')\n",
+    "    \n",
+    "    naas.notifications.send(email_to, subject, content)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "649dd6df-49a9-4c9a-a089-e75432222436",
+   "metadata": {},
+   "source": [
+    "### Load notion pages containing Recordings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4a83cd88-a7fc-4c64-bbda-cdd1217c284a",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "pages = database.query({\n",
+    "    \"filter\": {\n",
+    "        \"and\": [\n",
+    "        {\n",
+    "            \"property\": \"Transcript computed\",\n",
+    "            \"select\": {\n",
+    "                \"is_empty\": True\n",
+    "            }\n",
+    "        },\n",
+    "        {\n",
+    "            \"property\": \"Recording\",\n",
+    "            \"url\": {\n",
+    "                \"is_not_empty\": True\n",
+    "            }\n",
+    "        }\n",
+    "    ]\n",
+    "    }\n",
+    "})\n",
+    "len(pages)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "949d4a76-9e00-454d-aafe-2c1ef67cfbf6",
+   "metadata": {},
+   "source": [
+    "### Download recording"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "295eca11-6e46-48be-bda5-757bbd452294",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "class UnknownSource(Exception):\n",
+    "    \"\"\"This class is an exception used to identify the fact that we do not know how\n",
+    "    to download a recording.\n",
+    "    \"\"\"\n",
+    "    pass\n",
+    "\n",
+    "def download_recording(url, out):\n",
+    "    \n",
+    "    if 'drive.google.com' in url:\n",
+    "        gdown.download(url, out, quiet=False, fuzzy=True)\n",
+    "    else:\n",
+    "        raise UnknownSource('Do not know how to download recording.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e34b8743-d8be-47c0-8be7-9ab13f850889",
+   "metadata": {},
+   "source": [
+    "### Upload to S3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6440f67d-eeb1-4840-af56-3c115782d075",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def upload_to_s3(filename):\n",
+    "    s3 = boto3.client('s3', aws_access_key_id=AWS_ACCESS_KEY_ID, aws_secret_access_key=AWS_SECRET_ACCESS_KEY)\n",
+    "\n",
+    "    with open(filename, \"rb\") as f:\n",
+    "        s3.upload_fileobj(f, BUCKET_NAME, filename)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e5db8614-3396-4e63-9794-c9f80c1fe2d2",
+   "metadata": {},
+   "source": [
+    "### Create transcribe job"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "782997dd-adda-4e46-8fb2-271af3914de5",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def create_transcribe_job(job_name, filename, media_format='mp4'):\n",
+    "    \n",
+    "    transcribe = boto3.client('transcribe', aws_access_key_id=AWS_ACCESS_KEY_ID, aws_secret_access_key=AWS_SECRET_ACCESS_KEY, region_name=AWS_REGION)\n",
+    "    result = transcribe.start_transcription_job(TranscriptionJobName=job_name,\n",
+    "        MediaFormat=media_format,\n",
+    "        Media={\n",
+    "            'MediaFileUri': 's3://{0}/{1}'.format(BUCKET_NAME, filename)\n",
+    "        },\n",
+    "        Settings={\n",
+    "            'ShowSpeakerLabels': True,\n",
+    "            'MaxSpeakerLabels': 5\n",
+    "        },\n",
+    "        OutputBucketName=BUCKET_NAME,\n",
+    "        OutputKey=f'{filename}.json',\n",
+    "        IdentifyLanguage=True)\n",
+    "    return result"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "57decca6-2dc8-47d1-986f-b966a9fe2c00",
+   "metadata": {},
+   "source": [
+    "### Get transcription job status"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "32970541-b125-4900-8445-da5540d4f8bc",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def get_transcribe_job_status(job_name):    \n",
+    "    transcribe = boto3.client('transcribe', aws_access_key_id=AWS_ACCESS_KEY_ID, aws_secret_access_key=AWS_SECRET_ACCESS_KEY, region_name='eu-west-3')\n",
+    "    result = transcribe.get_transcription_job(TranscriptionJobName=f'{job_name}')\n",
+    "    return result"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1938a195-4e7c-4421-8974-95a8f568ba5c",
+   "metadata": {},
+   "source": [
+    "### Download from s3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d8387d5e-242a-417b-8b10-e7d51f161044",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def download_from_s3(object_name):\n",
+    "    s3 = boto3.client('s3', aws_access_key_id=AWS_ACCESS_KEY_ID, aws_secret_access_key=AWS_SECRET_ACCESS_KEY)\n",
+    "    local_store_path = os.path.join('/', 'tmp', object_name)\n",
+    "    with open(local_store_path, 'wb') as f:\n",
+    "        s3.download_fileobj(BUCKET_NAME, object_name, f)\n",
+    "        return local_store_path\n",
+    "    return ''"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "406bd274-2cea-4c42-b76d-38339507abfd",
+   "metadata": {},
+   "source": [
+    "### Convert transcript"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4d0b880a-4c74-44fb-b7c4-eec1bc7561da",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def convert_transcript(filename):\n",
+    "    with codecs.open(filename+'.txt', 'w', 'utf-8') as w:\n",
+    "        with codecs.open(filename, 'r', 'utf-8') as f:\n",
+    "            data=json.loads(f.read())\n",
+    "            labels = data['results']['speaker_labels']['segments']\n",
+    "            speaker_start_times={}\n",
+    "            for label in labels:\n",
+    "                for item in label['items']:\n",
+    "                    speaker_start_times[item['start_time']] =item['speaker_label']\n",
+    "            items = data['results']['items']\n",
+    "            lines=[]\n",
+    "            line=''\n",
+    "            time=0\n",
+    "            speaker='null'\n",
+    "            i=0\n",
+    "            for item in items:\n",
+    "                i=i+1\n",
+    "                content = item['alternatives'][0]['content']\n",
+    "                if item.get('start_time'):\n",
+    "                    current_speaker=speaker_start_times[item['start_time']]\n",
+    "                elif item['type'] == 'punctuation':\n",
+    "                    line = line+content\n",
+    "                if current_speaker != speaker:\n",
+    "                    if speaker:\n",
+    "                        lines.append({'speaker':speaker, 'line':line, 'time':time})\n",
+    "                    line=content\n",
+    "                    speaker=current_speaker\n",
+    "                    time=item['start_time']\n",
+    "                elif item['type'] != 'punctuation':\n",
+    "                    line = line + ' ' + content\n",
+    "            lines.append({'speaker':speaker, 'line':line,'time':time})\n",
+    "            sorted_lines = sorted(lines,key=lambda k: float(k['time']))\n",
+    "            for line_data in sorted_lines:\n",
+    "                line='[' + str(datetime.timedelta(seconds=int(round(float(line_data['time']))))) + '] ' + line_data.get('speaker') + ': ' + line_data.get('line')\n",
+    "                w.write(line + '\\n\\n')\n",
+    "            return filename+'.txt'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "67b65907-876c-4a82-a393-5564028991e3",
+   "metadata": {},
+   "source": [
+    "### Text to chunks"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7007bedc-e2fa-4929-ac41-7bd75dd45b7b",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def text_to_chunks(text, chunk_size):\n",
+    "    chunks = []\n",
+    "    count = 0\n",
+    "    text_len = len(text)\n",
+    "    \n",
+    "    while count * chunk_size < text_len:\n",
+    "        chunks.append(text[count * chunk_size:count * chunk_size + chunk_size])\n",
+    "        count += 1\n",
+    "    return chunks"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7bae5ef5-0e2b-4597-bf46-98a7d22bc337",
+   "metadata": {},
+   "source": [
+    "### Handle Job"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "41b87290-5e6b-424f-adf7-fc64a72331d7",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def handle_job(job):\n",
+    "    print(f'Handling Job: {job}')\n",
+    "    recording_url = job.recording_url\n",
+    "    notion_page_id = job.notion_page_id\n",
+    "\n",
+    "    # Download recording\n",
+    "    download_location = f'{notion_page_id}'\n",
+    "    download_recording(recording_url, download_location)\n",
+    "    print(f'Downloaded file to {download_location}')\n",
+    "    \n",
+    "    # Upload file to s3.\n",
+    "    upload_to_s3(download_location)\n",
+    "    print(f'File uploaded to s3.')\n",
+    "\n",
+    "    # Create transcribe job.\n",
+    "    result = create_transcribe_job(job.id, download_location)\n",
+    "    print(f'Transcription job created.')\n",
+    "\n",
+    "    # Wait for transcription job to complete.\n",
+    "    waiting_for_job = True\n",
+    "    job_status = None\n",
+    "    transcript = \"\"\n",
+    "    while waiting_for_job:\n",
+    "        status = get_transcribe_job_status(job.id)\n",
+    "        job_status = _.get(status, 'TranscriptionJob.TranscriptionJobStatus')\n",
+    "        \n",
+    "        \n",
+    "        print(f'Waiting for job. Actual status \"{job_status}\"')\n",
+    "        if job_status == \"COMPLETED\":\n",
+    "            print(f'{job}: AWS Transcribe job completed')\n",
+    "            waiting_for_job = False\n",
+    "\n",
+    "            media_file_uri = _.get(status, 'TranscriptionJob.Media.MediaFileUri')\n",
+    "            transcript_file_uri = _.get(status, 'TranscriptionJob.Transcript.TranscriptFileUri')\n",
+    "            \n",
+    "            \n",
+    "            local_store_path = download_from_s3(transcript_file_uri.split('/')[-1])\n",
+    "            print(f'Transcript downloaded {local_store_path}')\n",
+    "            converted_transcript_path = convert_transcript(local_store_path)\n",
+    "            \n",
+    "            \n",
+    "            with open(converted_transcript_path, 'r') as tr:\n",
+    "                for line in tr.readlines():\n",
+    "                    transcript = transcript + line\n",
+    "            \n",
+    "            os.remove(local_store_path)\n",
+    "            os.remove(converted_transcript_path)\n",
+    "            \n",
+    "        elif job_status == \"IN_PROGRESS\":\n",
+    "            print(f'Job in progress')\n",
+    "            time.sleep(5)\n",
+    "\n",
+    "        elif job_status not in ['COMPLETED', 'IN_PROGRESS', 'QUEUED']:\n",
+    "            waiting_for_job = False\n",
+    "            print(f'This job might be in error state.')\n",
+    "            print(_.get(status, 'TranscriptionJob.FailureReason'))\n",
+    "            raise Exception(f'Error while running aws transcribe. {_.get(status, \"TranscriptionJob.FailureReason\")}')\n",
+    "    \n",
+    "    if transcript != '' and job_status == \"COMPLETED\":\n",
+    "        notion_page_id = notion_page_id\n",
+    "        page = notion.page.get(notion_page_id)\n",
+    "        print(f'Adding toggle.')\n",
+    "        page.toggle('Transcript')\n",
+    "        page.update()\n",
+    "        for block in page.get_blocks():\n",
+    "            if block.type == 'toggle' and _.get(block, 'toggle.text[0].plain_text') == 'Transcript':\n",
+    "                block_id = block.id\n",
+    "                children_blocks = []\n",
+    "                for chunk in text_to_chunks(transcript, 2000):\n",
+    "                    child = BlockTypeFactory.new_default(type='paragraph', payload=chunk)\n",
+    "                    children_blocks.append(child)\n",
+    "                    \n",
+    "                notion.block.append(block_id, children_blocks)\n",
+    "                page.select(\"Transcript computed\", \"True\")\n",
+    "                page.update()\n",
+    "                print(f'Transcript added to notion page {notion_page_id}.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "baa034ab-bb85-483e-8c18-b91376f1fa66",
+   "metadata": {},
+   "source": [
+    "### Create Job class"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6610670c-cc3a-48f2-ad85-0313a813abb0",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "class Job:\n",
+    "    def __init__(self, notion_page_id, recording_url, job_id=None):\n",
+    "        self.notion_page_id = notion_page_id\n",
+    "        self.recording_url = recording_url\n",
+    "        self.id = job_id if job_id else str(uuid.uuid4())\n",
+    "    \n",
+    "    def __str__(self):\n",
+    "        return f'Job ID = {self.id} Notion Page Id = {self.notion_page_id} Recording URL = {self.recording_url}'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "19eee472-22b8-4ff3-84ee-e26f09f1b984",
+   "metadata": {},
+   "source": [
+    "## Output"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5698361c-2bda-4f81-8ddf-0df6ae92430a",
+   "metadata": {},
+   "source": [
+    "### Handle all recordings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6a534a5a-90e7-4cf2-beee-a01002faf17a",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "for page in pages:\n",
+    "    recording_url = _.get(page.properties, 'Recording.url')\n",
+    "    \n",
+    "    if recording_url != None:\n",
+    "        job = Job(page.id, recording_url)\n",
+    "        try:\n",
+    "            handle_job(job)\n",
+    "        except Exception as e:\n",
+    "            page = notion.page.get(job.notion_page_id)\n",
+    "            \n",
+    "            send_error_notification(page.url, str(e))   \n",
+    "            page.select(\"Transcript computed\", \"ERROR\")\n",
+    "            page.update()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6b19a035-0e75-4344-b539-c79b35238b4d",
+   "metadata": {},
+   "source": [
+    "# Schedule this job"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9cd1241f-021a-4fa7-bdef-5b81aef1d0ed",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "naas.scheduler.add(cron=\"0 * * * *\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This notebook is used to automatically add to a notion page, the transcript of a recording that would be found in the `Recording` property of that same page.

Recordings can be in any language compatible with AWS transcribe ([Here is the list](https://docs.aws.amazon.com/transcribe/latest/dg/supported-languages.html))

As of today, you also need to upload the recordings on Google Drive. (Feel free to open an issue [here](https://github.com/jupyter-naas/awesome-notebooks/issues/new?assignees=&labels=&template=template-request.md&title=Notion%20-%20Automatic%20transcribe%20recording%20-%20Add%20Zoom%20recording%20sources) if you want more recording sources like Zoom, etc to be developed.)
