### PR TITLE
Sendinblue - Get number of emails sent

### DIFF
--- a/Sendinblue/Sendinblue_Get_no_of_emails_sent.ipynb
+++ b/Sendinblue/Sendinblue_Get_no_of_emails_sent.ipynb
@@ -240,7 +240,7 @@
     "tags": []
    },
    "source": [
-    "### Get the number of undelivered emails: soft bounce + hard bounce"
+    "### Get the number of emails sent"
    ]
   },
   {

--- a/Sendinblue/Sendinblue_Get_no_of_emails_sent.ipynb
+++ b/Sendinblue/Sendinblue_Get_no_of_emails_sent.ipynb
@@ -1,0 +1,305 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "latin-packing",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-02-23T14:22:16.610471Z",
+     "iopub.status.busy": "2021-02-23T14:22:16.610129Z",
+     "iopub.status.idle": "2021-02-23T14:22:16.627784Z",
+     "shell.execute_reply": "2021-02-23T14:22:16.626866Z",
+     "shell.execute_reply.started": "2021-02-23T14:22:16.610384Z"
+    },
+    "papermill": {},
+    "tags": []
+   },
+   "source": [
+    "<img width=\"10%\" alt=\"Naas\" src=\"https://landen.imgix.net/jtci2pxwjczr/assets/5ice39g4.png?w=160\"/>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "compressed-wilson",
+   "metadata": {
+    "papermill": {},
+    "tags": []
+   },
+   "source": [
+    "# Sendinblue - Get no of emails sent\n",
+    "<a href=\"https://app.naas.ai/user-redirect/naas/downloader?url=https://raw.githubusercontent.com/jupyter-naas/awesome-notebooks/master/Sendinblue/Sendinblue_Get_no_of_emails_sent.ipynb\" target=\"_parent\"><img src=\"https://naasai-public.s3.eu-west-3.amazonaws.com/open_in_naas.svg\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "religious-programmer",
+   "metadata": {
+    "papermill": {},
+    "tags": []
+   },
+   "source": [
+    "**Tags:** #emails #campaign #sent #emailcampaigns #marketing #sendinblue #operations #snippet"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1fe9f56e-561c-4f52-aef8-b861c9462107",
+   "metadata": {
+    "papermill": {},
+    "tags": []
+   },
+   "source": [
+    "**Author:** [Minura Punchihewa](https://www.linkedin.com/in/minurapunchihewa/)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d5ec3cc1-b056-42d1-82b2-c7433c68f8c1",
+   "metadata": {
+    "papermill": {},
+    "tags": []
+   },
+   "source": [
+    "This notebook get the number of undelivered emails"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "distinguished-truth",
+   "metadata": {
+    "papermill": {},
+    "tags": []
+   },
+   "source": [
+    "## Input"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "numeric-mediterranean",
+   "metadata": {
+    "papermill": {},
+    "tags": []
+   },
+   "source": [
+    "### Import libraries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "potential-surfing",
+   "metadata": {
+    "papermill": {},
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import requests\n",
+    "import json\n",
+    "import naas"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f0c7a5bb",
+   "metadata": {
+    "papermill": {},
+    "tags": []
+   },
+   "source": [
+    "### Setup Sendinblue\n",
+    "[How to get your Sendinblue API KEY?](https://developers.sendinblue.com/docs#:~:text=Generate%20your%20API%20key%20to,key%20%60api%2Dkey%60.)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "89015afb",
+   "metadata": {
+    "papermill": {},
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "SENDINBLUE_API_KEY = naas.secret.get(name=\"SENDINBLUE_API_KEY\") or \"ENTER_YOUR_SENDINBLUE_API_KEY\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aggressive-trustee",
+   "metadata": {
+    "papermill": {},
+    "tags": []
+   },
+   "source": [
+    "### Variable"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "continuous-melbourne",
+   "metadata": {
+    "papermill": {},
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "campaign_name = \"Minura's Campaign\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "registered-showcase",
+   "metadata": {
+    "papermill": {},
+    "tags": []
+   },
+   "source": [
+    "## Model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "tested-astrology",
+   "metadata": {
+    "papermill": {},
+    "tags": []
+   },
+   "source": [
+    "### Send request to Sendinblue API"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "crude-louisville",
+   "metadata": {
+    "papermill": {},
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "response = requests.get(\n",
+    "    'https://api.sendinblue.com/v3/emailCampaigns',\n",
+    "    headers={\n",
+    "        'Accept': 'application/json',\n",
+    "        'api-key': SENDINBLUE_API_KEY\n",
+    "    }\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "lonely-pacific",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-07-02T23:32:10.789097Z",
+     "iopub.status.busy": "2021-07-02T23:32:10.788829Z",
+     "iopub.status.idle": "2021-07-02T23:32:10.796900Z",
+     "shell.execute_reply": "2021-07-02T23:32:10.796358Z",
+     "shell.execute_reply.started": "2021-07-02T23:32:10.789033Z"
+    },
+    "papermill": {},
+    "tags": []
+   },
+   "source": [
+    "## Output"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "890f7c86-b7bb-4f5d-9a1b-e492dd9580fd",
+   "metadata": {
+    "papermill": {},
+    "tags": []
+   },
+   "source": [
+    "### Get the campaign"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "9c4e3b7b-6440-4844-8054-265f1aec65eb",
+   "metadata": {
+    "papermill": {},
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "campaign = next(item for item in json.loads(response.text)['campaigns'] if item[\"name\"] == campaign_name)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "230ed6c0",
+   "metadata": {
+    "papermill": {},
+    "tags": []
+   },
+   "source": [
+    "### Get the number of undelivered emails: soft bounce + hard bounce"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "c4279612",
+   "metadata": {
+    "papermill": {},
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "campaign['statistics']['globalStats']['sent']"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.13"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "environment_variables": {},
+   "parameters": {},
+   "version": "2.3.3"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {},
+    "version_major": 2,
+    "version_minor": 0
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/Sendinblue/Sendinblue_Get_no_of_emails_sent.ipynb
+++ b/Sendinblue/Sendinblue_Get_no_of_emails_sent.ipynb
@@ -38,7 +38,7 @@
     "tags": []
    },
    "source": [
-    "**Tags:** #emails #campaign #sent #emailcampaigns #marketing #sendinblue #operations #snippet"
+    "**Tags:** #sendinblue #emails #campaign #sent #emailcampaigns #marketing #operations #snippet"
    ]
   },
   {
@@ -87,7 +87,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "potential-surfing",
    "metadata": {
     "papermill": {},
@@ -114,7 +114,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "89015afb",
    "metadata": {
     "papermill": {},
@@ -138,7 +138,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "continuous-melbourne",
    "metadata": {
     "papermill": {},
@@ -173,7 +173,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "crude-louisville",
    "metadata": {
     "papermill": {},
@@ -221,7 +221,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "9c4e3b7b-6440-4844-8054-265f1aec65eb",
    "metadata": {
     "papermill": {},
@@ -245,24 +245,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "c4279612",
    "metadata": {
     "papermill": {},
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "1"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "campaign['statistics']['globalStats']['sent']"
    ]
@@ -270,7 +259,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -284,7 +273,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.9.6"
   },
   "papermill": {
    "default_parameters": {},


### PR DESCRIPTION
Added the template for getting the number of emails sent through a Sendinblue campaign.

A couple of notes,

- This is for getting the number of emails sent through a specified campaign. If the idea is to get a report of the emails sent through all campaigns, let me know and I will update accordingly.
- I have used the attribute 'sent' to get the number of emails sent. There is another attribute 'delivered', however, I feel that 'sent' is the correct option?

Here is a link to the API documentation,
https://developers.sendinblue.com/reference/getemailcampaigns-1