### PR TITLE
[PR] added the template to merge multiple PDF files together

### DIFF
--- a/PDF/PDF_Merge_Multipe_PDFs.ipynb
+++ b/PDF/PDF_Merge_Multipe_PDFs.ipynb
@@ -1,0 +1,316 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "latin-packing",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-02-23T14:22:16.610471Z",
+     "iopub.status.busy": "2021-02-23T14:22:16.610129Z",
+     "iopub.status.idle": "2021-02-23T14:22:16.627784Z",
+     "shell.execute_reply": "2021-02-23T14:22:16.626866Z",
+     "shell.execute_reply.started": "2021-02-23T14:22:16.610384Z"
+    },
+    "papermill": {},
+    "tags": []
+   },
+   "source": [
+    "<img width=\"10%\" alt=\"Naas\" src=\"https://landen.imgix.net/jtci2pxwjczr/assets/5ice39g4.png?w=160\"/>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "compressed-wilson",
+   "metadata": {
+    "papermill": {},
+    "tags": []
+   },
+   "source": [
+    "# PDF - Extract Text and Merge Multiple PDFs \n",
+    "<a href=\"https://app.naas.ai/user-redirect/naas/downloader?url=https://raw.githubusercontent.com/jupyter-naas/awesome-notebooks/master/PDF/PDF_Merge_Multipe_PDFs.ipynb\" target=\"_parent\"><img src=\"https://naasai-public.s3.eu-west-3.amazonaws.com/open_in_naas.svg\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "religious-programmer",
+   "metadata": {
+    "papermill": {},
+    "tags": []
+   },
+   "source": [
+    "**Tags:** #pdf #extract #snippet #operations #text"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1fe9f56e-561c-4f52-aef8-b861c9462107",
+   "metadata": {
+    "papermill": {},
+    "tags": []
+   },
+   "source": [
+    "**Author:** [Minura Punchihewa](https://www.linkedin.com/in/minurapunchihewa/)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d5ec3cc1-b056-42d1-82b2-c7433c68f8c1",
+   "metadata": {
+    "papermill": {},
+    "tags": []
+   },
+   "source": [
+    "This notebook merges together multiple PDFs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "distinguished-truth",
+   "metadata": {
+    "papermill": {},
+    "tags": []
+   },
+   "source": [
+    "## Input"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "numeric-mediterranean",
+   "metadata": {
+    "papermill": {},
+    "tags": []
+   },
+   "source": [
+    "### Import libraries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "potential-surfing",
+   "metadata": {
+    "papermill": {},
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import io\n",
+    "import requests\n",
+    "from urllib.parse import urlparse\n",
+    "from PyPDF2 import PdfFileReader, PdfFileWriter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aggressive-trustee",
+   "metadata": {
+    "papermill": {},
+    "tags": []
+   },
+   "source": [
+    "### Variables"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "46af0552",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "input_pdf_files = [\"https://bitcoin.org/bitcoin.pdf\", \"https://ethereum.org/669c9e2e2027310b6b3cdce6e1c52962/Ethereum_Whitepaper_-_Buterin_2014.pdf\"]\n",
+    "ouput_pdf_file = \"merge.pdf\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "registered-showcase",
+   "metadata": {
+    "papermill": {},
+    "tags": []
+   },
+   "source": [
+    "## Model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bbb9f340",
+   "metadata": {},
+   "source": [
+    "### Define function to validate if string is a valid URL"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "854b8f94",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def is_url(url):\n",
+    "    try:\n",
+    "        result = urlparse(url)\n",
+    "        return all([result.scheme, result.netloc])\n",
+    "    except ValueError:\n",
+    "        return False"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "tested-astrology",
+   "metadata": {
+    "papermill": {},
+    "tags": []
+   },
+   "source": [
+    "### Define function to read PDF file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "crude-louisville",
+   "metadata": {
+    "papermill": {},
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def get_pdf(path):\n",
+    "    if is_url(path):\n",
+    "        remote_file = requests.get(path).content\n",
+    "        memory_file = io.BytesIO(remote_file)\n",
+    "        pdf_file = PdfFileReader(memory_file)\n",
+    "    else:\n",
+    "        pdf_file_obj = open(path, 'rb')\n",
+    "        pdf_file = PdfFileReader(pdf_file_obj)\n",
+    "        \n",
+    "    return pdf_file"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "lonely-pacific",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-07-02T23:32:10.789097Z",
+     "iopub.status.busy": "2021-07-02T23:32:10.788829Z",
+     "iopub.status.idle": "2021-07-02T23:32:10.796900Z",
+     "shell.execute_reply": "2021-07-02T23:32:10.796358Z",
+     "shell.execute_reply.started": "2021-07-02T23:32:10.789033Z"
+    },
+    "papermill": {},
+    "tags": []
+   },
+   "source": [
+    "## Output"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a962898a",
+   "metadata": {},
+   "source": [
+    "### Instantiate PDF writer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "ebdb1ba6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pdf_writer = PdfFileWriter()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "890f7c86-b7bb-4f5d-9a1b-e492dd9580fd",
+   "metadata": {
+    "papermill": {},
+    "tags": []
+   },
+   "source": [
+    "### Read PDF files and combine them"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "9c4e3b7b-6440-4844-8054-265f1aec65eb",
+   "metadata": {
+    "papermill": {},
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "for pdf_file in input_pdf_files:\n",
+    "    pdf_reader = get_pdf(pdf_file)\n",
+    "    \n",
+    "    for page_num in range(pdf_reader.numPages):\n",
+    "        page_obj = pdf_reader.getPage(page_num)\n",
+    "        pdf_writer.addPage(page_obj)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b1309001",
+   "metadata": {},
+   "source": [
+    "### Write the merged content into an output file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "c4279612",
+   "metadata": {
+    "papermill": {},
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "pdf_output_file = open(ouput_pdf_file, 'wb')\n",
+    "pdf_writer.write(pdf_output_file)\n",
+    "pdf_output_file.close()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.13"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "environment_variables": {},
+   "parameters": {},
+   "version": "2.3.3"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {},
+    "version_major": 2,
+    "version_minor": 0
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
I have added the template to extract text and merge multiple PDF files together. The initial idea was to merge two PDF files, however, a user can add as many paths as they like to the variable `input_pdf_files` under the `Variables` section. These paths can be URLs or the location of files in their computer.

The merged file will be saved in the current working directory under the name assigned to the `ouput_pdf_file` variable.

For this template to work the PyPDF2 package will need to be installed. This command to do is as follows,
`pip install PyPDF2`

